### PR TITLE
fix issue where help was failing to display in prod

### DIFF
--- a/pkg/commands/command.go
+++ b/pkg/commands/command.go
@@ -226,6 +226,7 @@ func Handler(ctx context.Context, client util.SlackClientInterface, evt slackeve
 					response = append(response, slack.MsgOptionTS(msg.ThreadTimeStamp))
 				}
 
+				log.Printf("responding to message in channel: %s", msg.Channel)
 				if attribute.ResponseIsEphemeral {
 					_, err = client.PostEphemeral(msg.Channel, msg.User, response...)
 				} else {

--- a/pkg/commands/help.go
+++ b/pkg/commands/help.go
@@ -11,24 +11,17 @@ import (
 )
 
 func compileHelp() slack.MsgOption {
-	messageBlocks := []slack.Block{}
+	helpText := strings.Builder{}
 	for _, attribute := range getAttributes() {
 		if attribute.ExcludeFromHelp {
 			continue
 		}
-		messageBlocks = append(messageBlocks,
-			slack.NewSectionBlock(
-				slack.NewTextBlockObject("plain_text", strings.Join(attribute.Commands, " "), false, false),
-				[]*slack.TextBlockObject{
-					//slack.NewTextBlockObject("mrkdwn", strings.Join(attribute.Commands, " "), false, false),
-					slack.NewTextBlockObject("plain_text", attribute.HelpMarkdown, false, false),
-				},
-				nil,
-			),
-			slack.NewDividerBlock(),
-		)
+		helpText.WriteString("- ")
+		helpText.WriteString(attribute.HelpMarkdown)
+		helpText.WriteString("\n")
 	}
-	return slack.MsgOptionBlocks(messageBlocks...)
+
+	return StringsToBlockUnfurl([]string{helpText.String()}, false, false)[0]
 }
 
 var HelpAttributes = data.Attributes{


### PR DESCRIPTION
slack was returning `invalid_blocks` only in prod.  i simplified the help text construction and its working in prod.