### PR TITLE
automatically meet platform token requirements for channels

### DIFF
--- a/data/knowledge.go
+++ b/data/knowledge.go
@@ -41,6 +41,10 @@ type KnowledgeAsset struct {
 	// This is a way to prevent the bot from being overly verbose aand spamming a thread.
 	WatchThreads bool `yaml:"respond_in_threads"`
 
+	// channels messages arriving on these channels will automatically have platform tokens 
+	// satisfied.
+	ChannelContext *ChannelContext `yaml:"channel_context"`
+	
 	// ShouldMatch is a list of strings that should match
 	ShouldMatch []string `yaml:"should_match"`
 
@@ -48,7 +52,15 @@ type KnowledgeAsset struct {
 	ShouldntMatch []string `yaml:"shouldnt_match"`
 
 	// RequireInChannel the attribute will only be recognized in a given channel(s).
-	RequireInChannel []string
+	RequireInChannel []string `yaml:"must_be_in_channels"`
+}
+
+type ChannelContext struct {
+	// contextPath is the path context to satisfy
+	ContextPath string `yaml:"context_path"`
+
+	// channels messages arriving on these channels will automatically have platform tokens
+	Channels []string `yaml:"channels"`
 }
 
 type TokenMatch struct {

--- a/pkg/knowledge/test/knowledge_prompts/vmware/channels/channel-test.yaml
+++ b/pkg/knowledge/test/knowledge_prompts/vmware/channels/channel-test.yaml
@@ -1,11 +1,16 @@
-name: UFO OR Test
+name: Channel context test
 markdown: >
-  spacecraft typically falls outside the expertise of this channel.  You might reach out in:
+  spacecraft typically falls outside the expertise of this channel.
+  You might reach out in:
   - #forum-ufo
 
   Here are some resources that may help:
 urls:
   - "<https://en.wikipedia.org/wiki/Unidentified_flying_object|UFOs>"
+channel_context:
+  channels:
+    - vmware
+  context_path: "vmware"
 on:
   type: or
   tokens:

--- a/pkg/util/command-stub.go
+++ b/pkg/util/command-stub.go
@@ -6,11 +6,19 @@ import (
 	"github.com/slack-go/slack"
 )
 
+var (
+	channelIDMaptest = map[string]string{
+		"test": "test",
+		"random": "random",
+		"vmware": "vmware",
+	}
+)
 type SlackClientInterface interface {
 	PostEphemeral(channelID string, userID string, options ...slack.MsgOption) (string, error)
 	PostMessage(channelID string, options ...slack.MsgOption) (string, string, error)
 	OpenConversation(params *slack.OpenConversationParameters) (*slack.Channel, bool, bool, error)
 	GetConversationReplies(params *slack.GetConversationRepliesParameters) (msgs []slack.Message, hasMore bool, nextCursor string, err error)
+	GetConversationInfo(input *slack.GetConversationInfoInput) (*slack.Channel, error)
 }
 
 type StubInterface struct {
@@ -30,4 +38,15 @@ func (s *StubInterface) OpenConversation(params *slack.OpenConversationParameter
 
 func (s *StubInterface) GetConversationReplies(params *slack.GetConversationRepliesParameters) (msgs []slack.Message, hasMore bool, nextCursor string, err error) {
 	return nil, false, "", fmt.Errorf("GetConversationReplies")
+}
+
+func (s *StubInterface) GetConversationInfo(input *slack.GetConversationInfoInput) (*slack.Channel, error) {
+	if channelID, ok := channelIDMaptest[input.ChannelID]; ok {
+		return &slack.Channel{
+			GroupConversation: slack.GroupConversation{
+				Name: channelID,
+			},
+		}, nil
+	}
+	return nil, fmt.Errorf("GetConversationInfo")
 }


### PR DESCRIPTION
adding a feature to the knowledge asset struct to where if messages arrive in specific channels, they are automatically provided with the platform context tokens.  for example, if a message arrives in an openshift channel and the knowledge asset is configured to do so, it will automatically attach the required platform tokens to the message.  For example:
```
name: Channel context test
markdown: >
  spacecraft typically falls outside the expertise of this channel.
  You might reach out in:
  - #forum-ufo
  Here are some resources that may help:
urls:
  - "<https://en.wikipedia.org/wiki/Unidentified_flying_object|UFOs>"
channel_context:
  channels:
    - vmware
  context_path: "vmware"
on:
  type: or
  tokens:
    - spacecraft
    - ufo
shouldnt_match:
  - "im a generic string that shouldnt match anything"
should_match:
  - "did you know how to repair a UFO?"
```

why? if a user is posting a message in a highly context specific channel we can likely assume they meant to include this context specific tokens.